### PR TITLE
Update kboot.conf

### DIFF
--- a/configs/releng-ps3/kboot/kboot.conf
+++ b/configs/releng-ps3/kboot/kboot.conf
@@ -1,4 +1,4 @@
 timeout=100
 default=archpower_install_ps3
 
-archpower_install_ps3="/arch/boot/ppc64/vmlinuz-linux-ps3 quiet arch=ppc archisobasedir=arch archisolabel=ARCH_202203 initrd=/arch/boot/ppc64/initramfs-linux-ps3.img read-only"
+archpower_install_ps3="/arch/boot/ppc64/vmlinuz-linux-ps3 arch=ppc64 archisobasedir=arch archisolabel=ARCH_202203 initrd=/arch/boot/ppc64/initramfs-linux-ps3.img read-only"


### PR DESCRIPTION
Fixed boot related issued on PS3 platform. Proper boot method is ppc64 or ppc6432. Removed "quiet" flag by default as the PS3 sometimes shows *interesting* errors while booting which are good to have.